### PR TITLE
"Fix" integration test

### DIFF
--- a/licensor_fetch/src/main.rs
+++ b/licensor_fetch/src/main.rs
@@ -86,7 +86,7 @@ fn main() {
 
     let mut licenses_path = resources_path.clone();
     licenses_path.push("licenses");
-    let mut exceptions_path = resources_path.clone();
+    let mut exceptions_path = resources_path;
     exceptions_path.push("exceptions");
 
     let mut lld_archive = Archive::new(decoded_archive.as_slice());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -69,7 +69,7 @@ fn license_and_name() {
         .assert()
         .success()
         .stdout(predicates::str::starts_with(
-            "MIT License Copyright (c) 2020 Raphaël Thériault\n",
+            "MIT License Copyright (c) 2021 Raphaël Thériault\n",
         ))
         .stderr(predicates::str::is_empty());
 }


### PR DESCRIPTION
"Fix" the integration test for 2021

* Bump year in integration test from 2020 -> 2021 until the test is properly addressed
* Remove redundant clone to make clippy happy/allow pre-commit hooks to pass